### PR TITLE
chore: update BigLep username

### DIFF
--- a/gh_slack_users.json
+++ b/gh_slack_users.json
@@ -1,7 +1,7 @@
 {
   "bajtos": "U06QNB50BJA",
   "beck-8": "U016N5KFU8G",
-  "biglep": "U01MVUHC342",
+  "BigLep": "U01MVUHC342",
   "hugomrdias": "UEWE17CLC",
   "juliangruber": "U06R7KFKMLZ",
   "Kubuxu": "UGAD953M4",


### PR DESCRIPTION
Usernames on GH are case sensitive, so in the update on Slack this conversion did not properly propagated.