### PR TITLE
fix: exclude approved reviewers from awaiting review notifications

### DIFF
--- a/foc_wg_pr_notifier.py
+++ b/foc_wg_pr_notifier.py
@@ -325,20 +325,6 @@ class FOCWGNotifier:
                         if reviewer_name:
                             reviewers.add(reviewer_name)
 
-                # Also include people who have actually submitted reviews
-                latest_reviews = pr.get('latestReviews', {}).get('nodes', [])
-                for review in latest_reviews:
-                    if not review:
-                        continue
-                    reviewer_login = review.get('author', {}).get('login')
-                    state = review.get('state', '')
-                    # Include reviewers who still need to act, skip bots
-                    # Exclude DISMISSED (review invalidated) and APPROVED (already approved)
-                    if (reviewer_login and state not in ('DISMISSED', 'APPROVED')
-                            and 'bot' not in reviewer_login.lower()
-                            and reviewer_login != 'copilot-pull-request-reviewer'):
-                        reviewers.add(reviewer_login)
-
                 # Remove the PR author from reviewers (they aren't reviewing their own PR)
                 pr_author = pr.get('author', {}).get('login')
                 reviewers.discard(pr_author)


### PR DESCRIPTION
Reviewers who already approved a PR were still listed under "PR Awaiting Your Review" because the latestReviews filter only excluded DISMISSED reviews. Now also excludes APPROVED reviews so people like juliangruber on synapse-sdk#538 aren't nagged after approving for example