### PR TITLE
chore: update foc-wg-pr-notifier to post in foc-bots channel

### DIFF
--- a/.github/workflows/foc-wg-pr-notifier.yml
+++ b/.github/workflows/foc-wg-pr-notifier.yml
@@ -42,6 +42,6 @@ jobs:
           # GitHub PAT with `read:project` organization permission
           # Set up by @rjan90 on 2026-01-12 using FilOzzy PAT
           GITHUB_TOKEN: ${{ secrets.FOC_WG_NOTIFIER_PAT }}
-          # Slack incoming webhook URL for #foc-wg channel
+          # Slack incoming webhook URL for #foc-bots
           # Set up by @rjan90 on 2026-01-06 using "FOC-WG PR Notifier" Slack app
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This is particularly useful for investigating storage provider issues and tracki
 ### 📢 FOC-WG PR Notifier
 **File:** `foc_wg_pr_notifier.py`
 
-Automated daily notification system that fetches open PRs from [FilOzone GitHub Project 14 (View 32)](https://github.com/orgs/FilOzone/projects/14/views/32) and posts a formatted summary to the `#foc-wg` Slack channel.
+Automated daily notification system that fetches open PRs from [FilOzone GitHub Project 14 (View 32)](https://github.com/orgs/FilOzone/projects/14/views/32) and posts a formatted summary to the `#foc-bots` Slack channel.
 
 **Features:**
 - Queries GitHub Project 14 via GraphQL API

--- a/foc_wg_pr_notifier.py
+++ b/foc_wg_pr_notifier.py
@@ -3,7 +3,7 @@
 FOC-WG PR Notifier
 
 This script queries FilOzone GitHub Project 14 for open PRs matching view 32 filters
-and posts a daily summary to the #foc-wg Slack channel.
+and posts a daily summary to #foc-bots in Slack via incoming webhook.
 
 View 32 filters (https://github.com/orgs/FilOzone/projects/14/views/32):
 - is:pr


### PR DESCRIPTION
Update foc-wg-pr-notifier to post in foc-bots channel. The `SLACK_WEBHOOK_URL` has been updated in the repo