### PR TITLE
feat: standardise SP approval review tracking with issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/sp-approval-review.md
+++ b/.github/ISSUE_TEMPLATE/sp-approval-review.md
@@ -1,12 +1,22 @@
 ---
 name: SP Approval Review
-about: Track a Storage Provider (SP) approval review and decision
-title: "[SP Approval Review] f0xxxx"
+about: Track an SP approval decision — new approval, breach review, or periodic check
+title: "[SP Approval] f0xxxx"
 labels: ["sp-approval-review"]
 assignees: []
 ---
 
 ## SP Approval Review
+
+### Review Type
+
+- [ ] **New approval** — SP is being approved for the first time
+- [ ] **Breach review** — approved SP has breached SLA thresholds
+- [ ] **Periodic check** — routine re-verification of an approved SP
+
+> Some sections below are only required for breach reviews. These are marked _(breach review only)_.
+
+---
 
 ### SP Details
 - **SP ID:**  
@@ -16,14 +26,19 @@ assignees: []
 
 ### Review Trigger
 - **Time review started (UTC):**  
-- **Trigger condition:**  
-  <!-- e.g. Storage success <97%, Retrieval failures, Retention faults -->
+- **Trigger:**  
+  <!-- New approval: e.g. SP met sustained thresholds, requested approval -->
+  <!-- Breach review: e.g. Storage success <97%, Retrieval failures, Retention faults -->
+  <!-- Periodic check: e.g. Quarterly review, post-incident re-verification -->
 
 ---
 
 ### Metrics
 
-**Failing metric(s):**
+<!-- For new approvals: record observed performance against thresholds. -->
+<!-- For breach reviews: record the failing metric(s). -->
+
+**Metric(s):**
 - 
 
 **Observed value(s):**
@@ -34,7 +49,7 @@ assignees: []
 
 ---
 
-### Investigation Window
+### Investigation Window _(breach review only)_
 - **Investigation deadline (UTC):**  
 - **Within maintenance window?** Yes / No  
 
@@ -42,16 +57,16 @@ assignees: []
 
 ### Communication
 
-- **SP notified?** Yes / No  
+- **SP notified / engaged?** Yes / No  
 - **Channel used:**  
   <!-- #pdp-endorsed-sp OR #fil-pdp-mainnet-launch -->
 
 - **SP response (if any):**
-  <!-- brief summary -->
+  <!-- Brief summary -->
 
 ---
 
-### Diagnosis
+### Diagnosis _(breach review only)_
 
 **Current assessment:**
 - [ ] SP-side issue  
@@ -66,19 +81,25 @@ assignees: []
 
 ### Outcome
 
-- [ ] Recovered within investigation window  
-- [ ] Unapproved  
+- [ ] **Approved** — SP added to approved list _(new approval / periodic check)_
+- [ ] **Not approved** — SP did not meet requirements _(new approval)_
+- [ ] **Recovered** within investigation window _(breach review)_
+- [ ] **Unapproved** _(breach review)_
 
 - **Decision time (UTC):**
+- **Decision owner:**  
+  <!-- The approver responsible for this decision -->
 
 ---
 
 ### Actions Taken
 
+- [ ] SP newly approved  
 - [ ] SP remained approved  
 - [ ] SP unapproved  
 - [ ] Follow-up issue created  
 - [ ] Escalated  
+- [ ] Added to approved list / Notion record updated  
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/sp-approval-review.md
+++ b/.github/ISSUE_TEMPLATE/sp-approval-review.md
@@ -1,0 +1,96 @@
+---
+name: SP Approval Review
+about: Track a Storage Provider (SP) approval review and decision
+title: "[SP Approval Review] f0xxxx"
+labels: ["sp-approval-review"]
+assignees: []
+---
+
+## SP Approval Review
+
+### SP Details
+- **SP ID:**  
+- **SP Name (optional):**
+
+---
+
+### Review Trigger
+- **Time review started (UTC):**  
+- **Trigger condition:**  
+  <!-- e.g. Storage success <97%, Retrieval failures, Retention faults -->
+
+---
+
+### Metrics
+
+**Failing metric(s):**
+- 
+
+**Observed value(s):**
+- 
+
+**Threshold(s):**
+- 
+
+---
+
+### Investigation Window
+- **Investigation deadline (UTC):**  
+- **Within maintenance window?** Yes / No  
+
+---
+
+### Communication
+
+- **SP notified?** Yes / No  
+- **Channel used:**  
+  <!-- #pdp-endorsed-sp OR #fil-pdp-mainnet-launch -->
+
+- **SP response (if any):**
+  <!-- brief summary -->
+
+---
+
+### Diagnosis
+
+**Current assessment:**
+- [ ] SP-side issue  
+- [ ] Dealbot / tooling issue  
+- [ ] Network / external issue  
+- [ ] Unknown  
+
+**Notes:**
+<!-- What do we think is happening? -->
+
+---
+
+### Outcome
+
+- [ ] Recovered within investigation window  
+- [ ] Unapproved  
+
+- **Decision time (UTC):**
+
+---
+
+### Actions Taken
+
+- [ ] SP remained approved  
+- [ ] SP unapproved  
+- [ ] Follow-up issue created  
+- [ ] Escalated  
+
+---
+
+### Links & Evidence
+
+- Dashboard (spdash):  
+- Dealbot runs:  
+- Logs / errors:  
+- Related issues:  
+
+---
+
+### Notes
+
+<!-- Anything else useful for future reference -->

--- a/.github/ISSUE_TEMPLATE/sp-approval-review.md
+++ b/.github/ISSUE_TEMPLATE/sp-approval-review.md
@@ -45,7 +45,12 @@ assignees: []
 - 
 
 **Threshold(s):**
-- 
+
+| Metric | Threshold | Minimum Sample Size |
+|--------|-----------|---------------------|
+| [Data Storage Success Rate](#data-storage-success-rate) | ≥ 97% | 200 |
+| [Data Retention Fault Rate](#data-retention-fault-rate) | ≤ 0.2% | 500 |
+| [Retrieval Success Rate](#retrieval-success-rate) | ≥ 97% | 200 |
 
 ---
 


### PR DESCRIPTION
Introduces a standard SP approval issue template in tpm-utils and updates the approval runbook to use it as the source of truth.

Standardises tracking across **all SP approval decisions** with clear triggers, UTC timestamps, ownership, and outcomes:

- **New approvals** — SP being approved for the first time
- **Breach reviews** — approved SP has breached SLA thresholds
- **Periodic checks** — routine re-verification of an approved SP

A `Review Type` selector at the top of the template scopes which sections apply. Breach-only sections (Investigation Window, Diagnosis) are marked explicitly. The Outcome and Actions Taken sections cover all three paths.

Other changes:

- **Decision owner** field added to the Outcome section so the responsible approver is recorded in the issue body, in addition to the GitHub assignee.
- **Communication** wording generalised from "notified" to "notified / engaged" so it reads naturally for new approvals too.

This improves operational consistency, auditability, and handover between approvers as we approach mainnet GA.