### PR TITLE
fix: FOC-WG notifier CI failure

### DIFF
--- a/foc-pr-report/foc_pr_report/foc_project14_client.py
+++ b/foc-pr-report/foc_pr_report/foc_project14_client.py
@@ -379,6 +379,9 @@ def rest_board_item_to_graphql_node(item: Dict[str, Any]) -> Dict[str, Any]:
     for r in content.get("requested_reviewers") or []:
         if isinstance(r, dict) and r.get("login"):
             review_nodes.append({"requestedReviewer": {"login": r["login"]}})
+    for team in content.get("requested_teams") or []:
+        if isinstance(team, dict) and team.get("name"):
+            review_nodes.append({"requestedReviewer": {"name": team["name"]}})
 
     repo_full: Optional[str] = None
     if "/repos/" in api_url:

--- a/foc_wg_pr_notifier.py
+++ b/foc_wg_pr_notifier.py
@@ -26,13 +26,22 @@ _FOC_PR_REPORT_DIR = os.path.join(_REPO_ROOT, "foc-pr-report")
 if _FOC_PR_REPORT_DIR not in sys.path:
     sys.path.insert(0, _FOC_PR_REPORT_DIR)
 
-from foc_pr_report.foc_project14_client import fetch_all_project_items, field_values_by_name
+from foc_pr_report.foc_project14_client import (
+    fetch_project_board_items_rest_filtered,
+    field_values_by_name,
+)
 
 # Milestones to exclude (view 32 filter)
 EXCLUDED_MILESTONES = [
     "MX: Priority and sequencing TBD",
     "M4.5: GA Fast Follows",
 ]
+NOTIFIER_FILTER = (
+    'is:pr '
+    '-status:"🎉 Done" '
+    '-milestone:"MX: Priority and sequencing TBD" '
+    '-milestone:"M4.5: GA Fast Follows"'
+)
 
 # Status constants for categorization
 AWAITING_REVIEW_STATUS = "🔎 Awaiting review"
@@ -77,8 +86,12 @@ class FOCWGNotifier:
             return {}
 
     def fetch_project_items(self) -> List[Dict[str, Any]]:
-        """Fetch all items from FilOzone Project 14 with pagination."""
-        return fetch_all_project_items(self.session, verbose=True)
+        """Fetch notifier-relevant project items via REST board filtering."""
+        return fetch_project_board_items_rest_filtered(
+            self.session,
+            filter_query=NOTIFIER_FILTER,
+            verbose=True,
+        )
 
     def filter_items(self, items: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         """Apply filters to the items (open PRs, non-draft, excluding certain milestones and Done status)."""


### PR DESCRIPTION
## Summary

This fixes the recurring failure in the `FOC-WG PR Notifier` GitHub Actions workflow: https://github.com/FilOzone/tpm-utils/actions/workflows/foc-wg-pr-notifier.yml

The notifier was still fetching Project 14 items through the all-items GraphQL query. That query now fails on at least one project card when resolving `reviewRequests.requestedReviewer`, returning `FORBIDDEN` / `Resource not accessible by personal access token` and aborting the whole job.

This change switches the notifier to the existing REST-based filtered project fetch used by `foc-pr-report`, which avoids the permission-sensitive GraphQL path and only fetches cards relevant to the notifier.

It also preserves team reviewer data by mapping REST `requested_teams` into the notifier's existing reviewer shape.

## Why

The workflow has been consistently failing in scheduled runs because the notifier crashes before it reaches Slack posting. Using the REST project-items endpoint makes the fetch path more robust for the current token permissions and reduces unnecessary full-board scanning.

## Validation

- `python3 -m py_compile foc_wg_pr_notifier.py foc-pr-report/foc_pr_report/foc_project14_client.py`
- `python3 foc_wg_pr_notifier.py --dry-run --token "$(gh auth token)"`
