### PR TITLE
feat(github-milestone-creator): add state field to close/reopen milestones

### DIFF
--- a/github-milestone-creator/README.md
+++ b/github-milestone-creator/README.md
@@ -1,11 +1,65 @@
 # GitHub Milestone Manager
 
-A Python script for creating and updating GitHub milestones across multiple repositories from a JSON configuration file.
+A Python script for creating, updating, and closing GitHub milestones across multiple repositories from a JSON configuration file.
+
+## Quick Reference
+
+```bash
+cd github-milestone-creator
+
+# Always dry-run first
+uv run github_milestone_manager.py --config <config>.json --token $(gh auth token) --dry-run
+
+# Execute for real
+uv run github_milestone_manager.py --config <config>.json --token $(gh auth token)
+```
+
+### Config file structure (JSON with comments supported)
+
+```jsonc
+{
+  "repos": ["owner/repo", ...],
+  "milestones": [
+    // Direct milestone: set fields explicitly
+    { "name": "M4.2: mainnet GA", "dueDate": "2026-06-12", "state": "open" },
+
+    // Reference milestone: sync name + due date from source of truth
+    { "referenceMilestoneUrl": "https://github.com/FilOzone/filecoin-services/milestone/11" },
+
+    // Close a milestone by name
+    { "name": "M4.1: mainnet ready", "state": "closed" },
+
+    // Rename an existing milestone
+    { "name": "New Name", "existingNameToRename": "Old Name" }
+  ]
+}
+```
+
+### Field semantics
+
+| Field | Omitted | `null` or `""` | Value |
+|-------|---------|----------------|-------|
+| `description` | Don't touch | Clear | Set |
+| `dueDate` | Don't touch | Clear | Set (YYYY-MM-DD) |
+| `state` | Don't touch | — | `"open"` or `"closed"` |
+
+### FOC milestone source-of-truth URLs (in `FilOzone/filecoin-services`)
+
+| Milestone | URL |
+|-----------|-----|
+| M4.0: mainnet staged | `/milestone/10` |
+| M4.1: mainnet ready | `/milestone/7` |
+| M4.2: mainnet GA | `/milestone/11` |
+| M4.5: GA Fast Follows | `/milestone/9` |
+| MX: Priority TBD | `/milestone/2` |
+
+---
 
 ## Overview
 
 This tool allows you to:
 - Create or update milestones across multiple GitHub repositories
+- Close or reopen milestones across repos
 - Sync milestones from a reference repository (source of truth)
 - Automatically match existing milestones by name
 - Rename existing milestones
@@ -18,6 +72,7 @@ This tool allows you to:
 - **Reference Milestones**: Sync milestones from one repository to others, automatically matching by name
 - **Automatic Matching**: Finds existing milestones by name before creating new ones
 - **Milestone Renaming**: Rename existing milestones using `existingNameToRename`
+- **Close/Reopen**: Set `"state": "closed"` or `"open"` to close or reopen milestones
 - **Flexible Updates**: Clear or update descriptions and due dates with null/empty string handling
 - **JSON Schema Validation**: Validates configuration files against a schema
 - **Comment Support**: Supports `//` and `/* */` style comments in JSON files
@@ -113,6 +168,10 @@ The configuration file is a JSON file with the following structure:
   - `null` or `""`: Field will be cleared
   - Date string: Field will be set to that date
   - Ignored if `referenceMilestoneUrl` is set
+- **`state`** (string, optional): `"open"` or `"closed"`
+  - Not present: State won't be changed
+  - `"closed"`: Closes the milestone
+  - `"open"`: Reopens the milestone
 
 ### Example Configurations
 

--- a/github-milestone-creator/github_milestone_manager.py
+++ b/github-milestone-creator/github_milestone_manager.py
@@ -270,6 +270,7 @@ class GitHubMilestoneManager:
         title: Optional[str] = None,
         description: Optional[str] = None,
         due_on: Optional[str] = None,
+        state: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Update an existing milestone."""
         url = f"{self.BASE_URL}/repos/{owner}/{repo}/milestones/{milestone_number}"
@@ -281,6 +282,8 @@ class GitHubMilestoneManager:
             data["description"] = description
         if due_on is not None:
             data["due_on"] = due_on
+        if state is not None:
+            data["state"] = state
 
         response = self._api_request("PATCH", url, json=data)
         response.raise_for_status()
@@ -376,9 +379,11 @@ class GitHubMilestoneManager:
             "previous_name": None,
             "previous_description": None,
             "previous_due_date": None,
+            "previous_state": None,
             "new_name": None,
             "new_description": None,
             "new_due_date": None,
+            "new_state": None,
         }
 
         try:
@@ -396,11 +401,12 @@ class GitHubMilestoneManager:
                     milestone_config["referenceMilestoneUrl"]
                 )
 
-            # Resolve description and due date
+            # Resolve description, due date, and state
             description = self.resolve_description(
                 milestone_config, reference_milestone
             )
             due_date = self.resolve_due_date(milestone_config, reference_milestone)
+            state = milestone_config.get("state")  # None means don't change
 
             # Find existing milestone to update - check BOTH names before creating:
             # 1. Check for milestone with existingNameToRename name (if provided)
@@ -438,6 +444,7 @@ class GitHubMilestoneManager:
             result["new_name"] = milestone_name
             result["new_description"] = description
             result["new_due_date"] = due_date
+            result["new_state"] = state
 
             # Determine if we're creating or updating
             if existing_milestone:
@@ -448,6 +455,7 @@ class GitHubMilestoneManager:
                     existing_milestone.get("description") or None
                 )
                 result["previous_due_date"] = existing_milestone.get("due_on") or None
+                result["previous_state"] = existing_milestone.get("state")
 
                 # If we found it by existingNameToRename, we need to rename it to the target name
                 # (which could be from referenceMilestoneUrl or the provided name)
@@ -463,6 +471,7 @@ class GitHubMilestoneManager:
                         title=milestone_name if needs_rename else None,
                         description=description,
                         due_on=due_date,
+                        state=state,
                     )
                     result["milestone_number"] = updated["number"]
                     result["action"] = "updated"
@@ -584,6 +593,12 @@ class GitHubMilestoneManager:
                                     "Due Date", None, new_due_date, is_date=True
                                 )
                             )
+                            if result["new_state"]:
+                                print(
+                                    self._format_value_change(
+                                        "State", None, result["new_state"]
+                                    )
+                                )
                         elif action == "update":
                             print(
                                 f"  Would UPDATE: {name} (milestone #{result['milestone_number']})"
@@ -608,6 +623,14 @@ class GitHubMilestoneManager:
                                     is_date=True,
                                 )
                             )
+                            if result["new_state"]:
+                                print(
+                                    self._format_value_change(
+                                        "State",
+                                        result["previous_state"],
+                                        result["new_state"],
+                                    )
+                                )
                     else:
                         if action == "created":
                             print(f"  ✅ Created: {name} - {result['milestone_url']}")
@@ -622,6 +645,12 @@ class GitHubMilestoneManager:
                                     "Due Date", None, new_due_date, is_date=True
                                 )
                             )
+                            if result["new_state"]:
+                                print(
+                                    self._format_value_change(
+                                        "State", None, result["new_state"]
+                                    )
+                                )
                         elif action == "updated":
                             print(f"  ✅ Updated: {name} - {result['milestone_url']}")
                             print(
@@ -644,6 +673,14 @@ class GitHubMilestoneManager:
                                     is_date=True,
                                 )
                             )
+                            if result["new_state"]:
+                                print(
+                                    self._format_value_change(
+                                        "State",
+                                        result["previous_state"],
+                                        result["new_state"],
+                                    )
+                                )
 
         return results
 

--- a/github-milestone-creator/github_milestone_manager.py
+++ b/github-milestone-creator/github_milestone_manager.py
@@ -248,6 +248,7 @@ class GitHubMilestoneManager:
         title: str,
         description: Optional[str] = None,
         due_on: Optional[str] = None,
+        state: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Create a new milestone."""
         url = f"{self.BASE_URL}/repos/{owner}/{repo}/milestones"
@@ -257,6 +258,8 @@ class GitHubMilestoneManager:
             data["description"] = description
         if due_on is not None:
             data["due_on"] = due_on
+        if state is not None:
+            data["state"] = state
 
         response = self._api_request("POST", url, json=data)
         response.raise_for_status()
@@ -491,6 +494,7 @@ class GitHubMilestoneManager:
                         milestone_name,
                         description=description,
                         due_on=due_date,
+                        state=state,
                     )
                     result["milestone_number"] = created["number"]
                     result["action"] = "created"

--- a/github-milestone-creator/milestones-m41-close-m42-sync-2026-05-04.json
+++ b/github-milestone-creator/milestones-m41-close-m42-sync-2026-05-04.json
@@ -24,7 +24,7 @@
   ],
   "milestones": [
     {
-      // Close M4.1: mainnet ready (sync description + date from source of truth)
+      // Close M4.1: mainnet ready (sync date from source of truth, description set to pointer URL)
       "referenceMilestoneUrl": "https://github.com/FilOzone/filecoin-services/milestone/7",
       "state": "closed"
     },

--- a/github-milestone-creator/milestones-m41-close-m42-sync-2026-05-04.json
+++ b/github-milestone-creator/milestones-m41-close-m42-sync-2026-05-04.json
@@ -1,0 +1,36 @@
+{
+  // Close M4.1 milestones and sync M4.2 due date (2026-06-12) from
+  // the master milestone at FilOzone/filecoin-services/milestone/11.
+  "repos": [
+    "FilOzone/SessionKeyRegistry",
+    "FilOzone/dealbot",
+    "FilOzone/early-repair",
+    "FilOzone/filecoin-cloud",
+    "FilOzone/filecoin-pay",
+    "FilOzone/filecoin-pay-auction-bot",
+    "FilOzone/filecoin-pay-explorer",
+    "FilOzone/filecoin-services",
+    "FilOzone/foc-devnet",
+    "FilOzone/fs-pm",
+    "FilOzone/infra",
+    "FilOzone/pdp",
+    "FilOzone/pdp-explorer",
+    "FilOzone/synapse-sdk",
+    "FilOzone/tpm-utils",
+    "filecoin-project/curio",
+    "filecoin-project/filecoin-pin",
+    "filecoin-project/filecoin-pin-website",
+    "filecoin-project/lotus"
+  ],
+  "milestones": [
+    {
+      // Close M4.1: mainnet ready (sync description + date from source of truth)
+      "referenceMilestoneUrl": "https://github.com/FilOzone/filecoin-services/milestone/7",
+      "state": "closed"
+    },
+    {
+      // Sync M4.2: mainnet GA (due date 2026-06-12 from master milestone)
+      "referenceMilestoneUrl": "https://github.com/FilOzone/filecoin-services/milestone/11"
+    }
+  ]
+}

--- a/github-milestone-creator/milestones-schema.json
+++ b/github-milestone-creator/milestones-schema.json
@@ -71,6 +71,11 @@
               }
             ],
             "description": "Due date for the milestone in ISO-8601 format (YYYY-MM-DD). Optional. Behavior: undefined/not present = field won't be touched; null or empty string \"\" = field will be cleared; date string (YYYY-MM-DD) = field will be set to that value. Ignored if referenceMilestoneUrl is set (reference milestone's due date takes precedence)."
+          },
+          "state": {
+            "type": "string",
+            "enum": ["open", "closed"],
+            "description": "State of the milestone. Optional. If set to 'closed', the milestone will be closed. If set to 'open', the milestone will be reopened. If not present, state won't be changed."
           }
         },
         "additionalProperties": false


### PR DESCRIPTION
## Summary

- Adds `"state": "open"/"closed"` support to the milestone manager script and schema, enabling bulk close/reopen of milestones across repos
- Closes M4.1 milestones and updates M4.2 due dates to 2026-06-12 (matching [FilOzone/filecoin-services milestone #11](https://github.com/FilOzone/filecoin-services/milestone/11)) across all 19 FOC repos
- Adds quick-reference section to README with field semantics table and FOC milestone URLs

## What was done

The config `milestones-m41-close-m42-sync-2026-05-04.json` has already been executed:
- **M4.1: mainnet ready** — closed across all 19 FOC repos
- **M4.2: mainnet GA** — due date updated from 2026-03-31 to 2026-06-12 across all 19 repos

## Test plan

- [x] Dry-run validated before execution
- [x] Executed successfully (36 updated, 1 created, 0 errors after retry)
- [x] Schema validation rejects invalid state values (tested with `"state": "invalid"`)
- [x] Verified lotus M4.1 closed after transient 504 retry

🤖 Generated with [Claude Code](https://claude.com/claude-code)