### PR TITLE
chore: add pre-commit lint hook matching CI

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Pre-commit hook: runs the same ruff checks as CI.
+# Install with: git config core.hooksPath .githooks
+
+set -euo pipefail
+
+echo "Running ruff lint..."
+uvx ruff check .
+
+echo "Running ruff format check..."
+uvx ruff format --check .
+
+echo "All lint checks passed."

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -4,6 +4,13 @@
 
 set -euo pipefail
 
+if ! command -v uvx &> /dev/null; then
+  echo "Error: 'uvx' is not installed or not on PATH."
+  echo "Install it via: curl -LsSf https://astral.sh/uv/install.sh | sh"
+  echo "See https://docs.astral.sh/uv/getting-started/installation/ for more options."
+  exit 1
+fi
+
 echo "Running ruff lint..."
 uvx ruff check .
 

--- a/README.md
+++ b/README.md
@@ -144,7 +144,8 @@ This runs integration tests across `github-projects-client`, `filozzy-mcp`, and 
    cd tpm-utils
    ```
 
-2. **Enable the pre-commit lint hook** (runs the same `ruff` checks as CI):
+2. **Enable the pre-commit lint hook** (runs the same `ruff` checks as CI).
+   Requires [`uv`](https://docs.astral.sh/uv/getting-started/installation/) (provides `uvx`).
    ```bash
    git config core.hooksPath .githooks
    ```

--- a/README.md
+++ b/README.md
@@ -144,9 +144,14 @@ This runs integration tests across `github-projects-client`, `filozzy-mcp`, and 
    cd tpm-utils
    ```
 
-2. **Review the documentation** for the specific tool you need
-3. **Set up any required dependencies** (Python 3, jq, etc.)
-4. **Follow the workflow steps** outlined in each documentation file
+2. **Enable the pre-commit lint hook** (runs the same `ruff` checks as CI):
+   ```bash
+   git config core.hooksPath .githooks
+   ```
+
+3. **Review the documentation** for the specific tool you need
+4. **Set up any required dependencies** (Python 3, jq, etc.)
+5. **Follow the workflow steps** outlined in each documentation file
 
 ## Contributing
 


### PR DESCRIPTION
## Summary

- Add `.githooks/pre-commit` that runs `uvx ruff check .` and `uvx ruff format --check .` — the same checks as the CI lint job
- Zero dependencies beyond `uvx` (already required for development)
- Opt-in with one command: `git config core.hooksPath .githooks`

## Test plan

- [x] Hook runs automatically on commit and catches lint/format issues
- [x] Verified hook passes on clean codebase
- [x] Documented setup in README Getting Started section

🤖 Generated with [Claude Code](https://claude.com/claude-code)