### PR TITLE
fix: foc-wg PR notifier workflow

### DIFF
--- a/foc_wg_pr_notifier.py
+++ b/foc_wg_pr_notifier.py
@@ -22,9 +22,11 @@ from urllib.parse import quote
 import argparse
 
 _REPO_ROOT = os.path.dirname(os.path.abspath(__file__))
+_GITHUB_PROJECTS_CLIENT_DIR = os.path.join(_REPO_ROOT, "github-projects-client")
 _FOC_PR_REPORT_DIR = os.path.join(_REPO_ROOT, "foc-pr-report")
-if _FOC_PR_REPORT_DIR not in sys.path:
-    sys.path.insert(0, _FOC_PR_REPORT_DIR)
+for _LOCAL_IMPORT_DIR in (_GITHUB_PROJECTS_CLIENT_DIR, _FOC_PR_REPORT_DIR):
+    if _LOCAL_IMPORT_DIR not in sys.path:
+        sys.path.insert(0, _LOCAL_IMPORT_DIR)
 
 from foc_pr_report.pr_enrichment import (  # noqa: E402
     fetch_project_board_items_rest_filtered,


### PR DESCRIPTION
## Summary

Fix the standalone FOC-WG PR notifier so it can import the sibling github-projects-client package from a plain GitHub Actions checkout.

## Root cause

The notifier added foc-pr-report to sys.path, but foc-pr-report now imports github_projects_client.api. The scheduled workflow only installs root requirements, so the notifier failed before reaching credential checks with ModuleNotFoundError.

## Validation

- python3 foc_wg_pr_notifier.py --dry-run now reaches the expected missing-token guard instead of an import traceback
- python3 -m py_compile foc_wg_pr_notifier.py foc-pr-report/foc_pr_report/pr_enrichment.py github-projects-client/github_projects_client/api.py