### PR TITLE
fix: add bounded FOC review stats window

### DIFF
--- a/foc-review-stats/README.md
+++ b/foc-review-stats/README.md
@@ -58,6 +58,9 @@ uv run foc-review-stats --weeks 1
 # Window starting from a specific date.
 uv run foc-review-stats --since 2026-04-01
 
+# Historical window, inclusive of both dates.
+uv run foc-review-stats --since 2026-03-01 --until 2026-03-31
+
 # Markdown table for Slack or a wiki.
 uv run foc-review-stats --format md -o stats.md
 
@@ -139,7 +142,7 @@ Matching is case-insensitive.
 |---|---|
 | `Contributor` | Display name from GitHub, falling back to login. |
 | `PRs` | PRs authored in the window. |
-| `Reviews` | Distinct PRs reviewed in the window (self-reviews and bot-authored PRs excluded). |
+| `Reviews` | Distinct PRs reviewed in the window (self-reviews and bot-authored PRs excluded). With `--until`, review submission timestamps are filtered to the requested date range. |
 | `Rev/PR` | `Reviews` divided by `PRs`. Below 1 means more authored than reviewed (review debt); above 1 means paying review forward. |
 | `Reviewed by (top N)` | Top reviewers of this contributor's PRs in the window. |
 | `Reviewed for (top N)` | Top authors whose PRs this contributor reviewed. |
@@ -153,6 +156,10 @@ light green when above 1.
   dropped entirely (its reviewers are not counted on that PR either).
 - Each distinct reviewer is counted once per PR regardless of how many review
   events they submitted.
+- When `--until` is set, the report uses an inclusive date window. PRs are
+  counted by PR creation timestamp, while reviews are counted by review
+  submission timestamp. This means a review in the requested window can count
+  even when the PR was created before the window.
 - Self-reviews (reviewer login equals author login) are skipped.
 - Active in window means at least one PR authored or one PR reviewed since the
   window start; contributors with zero activity are not shown.

--- a/foc-review-stats/README.md
+++ b/foc-review-stats/README.md
@@ -161,8 +161,8 @@ light green when above 1.
   submission timestamp. This means a review in the requested window can count
   even when the PR was created before the window.
 - Self-reviews (reviewer login equals author login) are skipped.
-- Active in window means at least one PR authored or one PR reviewed since the
-  window start; contributors with zero activity are not shown.
+- Active in window means at least one PR authored or one PR reviewed within
+  the requested report window; contributors with zero activity are not shown.
 - With `[team]` configured: PRs authored by anyone outside the team union are
   dropped, and reviews submitted by anyone outside the team union are not
   counted (so external one-off contributors don't appear).

--- a/foc-review-stats/foc_review_stats/cli.py
+++ b/foc-review-stats/foc_review_stats/cli.py
@@ -180,8 +180,7 @@ def main(argv: list[str] | None = None) -> None:
         fetch_repo_prs = github.fetch_repo_prs
     with ThreadPoolExecutor(max_workers=args.workers) as ex:
         futures = {
-            ex.submit(fetch_repo_prs, session, r, since_iso): r
-            for r in repo_list
+            ex.submit(fetch_repo_prs, session, r, since_iso): r for r in repo_list
         }
         for fut in as_completed(futures):
             repo = futures[fut]

--- a/foc-review-stats/foc_review_stats/cli.py
+++ b/foc-review-stats/foc_review_stats/cli.py
@@ -41,6 +41,13 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="ISO date (YYYY-MM-DD). Defaults to --weeks weeks before today.",
     )
     p.add_argument(
+        "--until",
+        help=(
+            "ISO end date (YYYY-MM-DD), inclusive. When set, counts PRs created "
+            "and reviews submitted from --since through --until."
+        ),
+    )
+    p.add_argument(
         "--weeks", type=int, default=6, help="Window length in weeks (default 6)."
     )
     p.add_argument(
@@ -105,7 +112,16 @@ def main(argv: list[str] | None = None) -> None:
         if args.since
         else (datetime.now(timezone.utc).date() - timedelta(weeks=args.weeks))
     )
+    until_date = date.fromisoformat(args.until) if args.until else None
+    if until_date is not None and until_date < since_date:
+        print("Error: --until must be on or after --since", file=sys.stderr)
+        sys.exit(2)
     since_iso = since_date.isoformat() + "T00:00:00Z"
+    until_iso = (
+        (until_date + timedelta(days=1)).isoformat() + "T00:00:00Z"
+        if until_date is not None
+        else None
+    )
     pushed_since = (since_date - timedelta(weeks=args.pushed_buffer_weeks)).isoformat()
 
     session = github.make_session(token)
@@ -147,14 +163,24 @@ def main(argv: list[str] | None = None) -> None:
     repo_list = sorted(repos)
 
     if not args.quiet:
-        print(f"Window: PRs created since {since_date}", file=sys.stderr)
+        if until_date is not None:
+            print(
+                f"Window: activity from {since_date} through {until_date}",
+                file=sys.stderr,
+            )
+        else:
+            print(f"Window: PRs created since {since_date}", file=sys.stderr)
         print(f"Repos: {len(repo_list)} (workers={args.workers})", file=sys.stderr)
 
     all_prs: list[dict] = []
     completed = 0
+    if until_date is not None:
+        fetch_repo_prs = github.fetch_repo_prs_updated_since
+    else:
+        fetch_repo_prs = github.fetch_repo_prs
     with ThreadPoolExecutor(max_workers=args.workers) as ex:
         futures = {
-            ex.submit(github.fetch_repo_prs, session, r, since_iso): r
+            ex.submit(fetch_repo_prs, session, r, since_iso): r
             for r in repo_list
         }
         for fut in as_completed(futures):
@@ -167,7 +193,13 @@ def main(argv: list[str] | None = None) -> None:
             if not args.quiet and completed % 25 == 0:
                 print(f"  ...{completed}/{len(repo_list)}", file=sys.stderr)
 
-    agg = stats.aggregate(all_prs, ignored_lower, in_scope_lower)
+    agg = stats.aggregate(
+        all_prs,
+        ignored_lower,
+        in_scope_lower,
+        since_iso=since_iso if until_date is not None else None,
+        until_iso=until_iso,
+    )
 
     if not args.quiet:
         print(
@@ -177,7 +209,13 @@ def main(argv: list[str] | None = None) -> None:
     names = github.fetch_display_names(session, sorted(agg.logins))
 
     renderer = RENDERERS[args.format]
-    output = renderer(agg, names, since_date.isoformat(), args.top)
+    output = renderer(
+        agg,
+        names,
+        since_date.isoformat(),
+        args.top,
+        until_date.isoformat() if until_date is not None else None,
+    )
 
     if args.output:
         Path(args.output).write_text(output + "\n", encoding="utf-8")

--- a/foc-review-stats/foc_review_stats/cli.py
+++ b/foc-review-stats/foc_review_stats/cli.py
@@ -175,12 +175,12 @@ def main(argv: list[str] | None = None) -> None:
     all_prs: list[dict] = []
     completed = 0
     if until_date is not None:
-        fetch_repo_prs = github.fetch_repo_prs_updated_since
+        fetch_repo_prs_fn = github.fetch_repo_prs_updated_since
     else:
-        fetch_repo_prs = github.fetch_repo_prs
+        fetch_repo_prs_fn = github.fetch_repo_prs
     with ThreadPoolExecutor(max_workers=args.workers) as ex:
         futures = {
-            ex.submit(fetch_repo_prs, session, r, since_iso): r for r in repo_list
+            ex.submit(fetch_repo_prs_fn, session, r, since_iso): r for r in repo_list
         }
         for fut in as_completed(futures):
             repo = futures[fut]

--- a/foc-review-stats/foc_review_stats/github.py
+++ b/foc-review-stats/foc_review_stats/github.py
@@ -126,10 +126,40 @@ query PRs($owner: String!, $name: String!, $cursor: String) {
       nodes {
         number
         createdAt
+        updatedAt
         author { __typename login }
         reviews(first: 100) {
           pageInfo { hasNextPage endCursor }
           nodes {
+            createdAt
+            author { __typename login }
+            state
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+_PRS_UPDATED_QUERY = """
+query PRsUpdated($owner: String!, $name: String!, $cursor: String) {
+  repository(owner: $owner, name: $name) {
+    pullRequests(
+      first: 50
+      after: $cursor
+      orderBy: {field: UPDATED_AT, direction: DESC}
+    ) {
+      pageInfo { hasNextPage endCursor }
+      nodes {
+        number
+        createdAt
+        updatedAt
+        author { __typename login }
+        reviews(first: 100) {
+          pageInfo { hasNextPage endCursor }
+          nodes {
+            createdAt
             author { __typename login }
             state
           }
@@ -147,6 +177,7 @@ query PRReviews($owner: String!, $name: String!, $number: Int!, $cursor: String)
       reviews(first: 100, after: $cursor) {
         pageInfo { hasNextPage endCursor }
         nodes {
+          createdAt
           author { __typename login }
           state
         }
@@ -205,6 +236,49 @@ def fetch_repo_prs(
         page = repo["pullRequests"]
         for pr in page["nodes"]:
             if pr["createdAt"] < since_iso:
+                done = True
+                break
+            reviews = pr.get("reviews") or {}
+            review_info = reviews.get("pageInfo") or {}
+            if review_info.get("hasNextPage"):
+                overflow = _fetch_overflow_reviews(
+                    session, owner, name, pr["number"], review_info["endCursor"]
+                )
+                reviews["nodes"] = (reviews.get("nodes") or []) + overflow
+                review_info["hasNextPage"] = False
+                pr["reviews"] = reviews
+            prs.append(pr)
+        if done or not page["pageInfo"]["hasNextPage"]:
+            return prs
+        cursor = page["pageInfo"]["endCursor"]
+    return prs
+
+
+def fetch_repo_prs_updated_since(
+    session: TokenSession, name_with_owner: str, since_iso: str
+) -> list[dict[str, Any]]:
+    """Fetch PRs updated on or after since_iso with embedded reviews.
+
+    This is used for bounded historical windows where reviews on PRs created
+    before the window still need to be counted if the review happened inside
+    the window.
+    """
+    owner, name = name_with_owner.split("/", 1)
+    prs: list[dict[str, Any]] = []
+    cursor: str | None = None
+    done = False
+    while not done:
+        data = graphql(
+            session,
+            _PRS_UPDATED_QUERY,
+            {"owner": owner, "name": name, "cursor": cursor},
+        )
+        repo = data.get("repository")
+        if not repo:
+            return prs
+        page = repo["pullRequests"]
+        for pr in page["nodes"]:
+            if pr["updatedAt"] < since_iso:
                 done = True
                 break
             reviews = pr.get("reviews") or {}

--- a/foc-review-stats/foc_review_stats/render.py
+++ b/foc-review-stats/foc_review_stats/render.py
@@ -18,6 +18,12 @@ def _ratio_str(created: int, reviewed: int) -> str:
     return f"{reviewed / created:.2f}"
 
 
+def _heading(since: str, until: str | None, separator: str) -> str:
+    if until:
+        return f"FOC review stats{separator}activity from {since} through {until}"
+    return f"FOC review stats{separator}PRs created since {since}"
+
+
 def _build_rows(
     agg: Aggregate, names: dict[str, str], top_n: int
 ) -> list[tuple[str, int, int, str, str, str]]:
@@ -64,7 +70,13 @@ def _format_table(
     return "\n".join(out)
 
 
-def render_text(agg: Aggregate, names: dict[str, str], since: str, top_n: int) -> str:
+def render_text(
+    agg: Aggregate,
+    names: dict[str, str],
+    since: str,
+    top_n: int,
+    until: str | None = None,
+) -> str:
     rows = _build_rows(agg, names, top_n)
     headers = [
         "Contributor",
@@ -76,7 +88,7 @@ def render_text(agg: Aggregate, names: dict[str, str], since: str, top_n: int) -
     ]
     aligns = ["<", ">", ">", ">", "<", "<"]
     lines = [
-        f"FOC review stats: PRs created since {since}",
+        _heading(since, until, ": "),
         "",
         _format_table(rows, headers, aligns),
         "",
@@ -85,7 +97,11 @@ def render_text(agg: Aggregate, names: dict[str, str], since: str, top_n: int) -
 
 
 def render_markdown(
-    agg: Aggregate, names: dict[str, str], since: str, top_n: int
+    agg: Aggregate,
+    names: dict[str, str],
+    since: str,
+    top_n: int,
+    until: str | None = None,
 ) -> str:
     rows = _build_rows(agg, names, top_n)
     headers = [
@@ -97,7 +113,7 @@ def render_markdown(
         f"Reviewed for (top {top_n})",
     ]
     out = [
-        f"FOC review stats (PRs created since {since})",
+        _heading(since, until, " (") + ")",
         "",
         "| " + " | ".join(headers) + " |",
         "|" + "|".join(["---"] * len(headers)) + "|",
@@ -108,7 +124,13 @@ def render_markdown(
     return "\n".join(out)
 
 
-def render_html(agg: Aggregate, names: dict[str, str], since: str, top_n: int) -> str:
+def render_html(
+    agg: Aggregate,
+    names: dict[str, str],
+    since: str,
+    top_n: int,
+    until: str | None = None,
+) -> str:
     rows = _build_rows(agg, names, top_n)
 
     def shade(ratio: str) -> str:
@@ -132,7 +154,7 @@ def render_html(agg: Aggregate, names: dict[str, str], since: str, top_n: int) -
 
     lines: list[str] = []
     lines.append('<meta charset="utf-8">')
-    lines.append(f"<h2>FOC review stats (PRs created since {esc(since)})</h2>")
+    lines.append(f"<h2>{esc(_heading(since, until, ' (') + ')')}</h2>")
     lines.append(
         '<table style="border-collapse:collapse; '
         'font-family:Arial, sans-serif; font-size:11pt;">'
@@ -165,7 +187,9 @@ def render_html(agg: Aggregate, names: dict[str, str], since: str, top_n: int) -
     return "\n".join(lines)
 
 
-RENDERERS: dict[str, Callable[[Aggregate, dict[str, str], str, int], str]] = {
+RENDERERS: dict[
+    str, Callable[[Aggregate, dict[str, str], str, int, str | None], str]
+] = {
     "text": render_text,
     "md": render_markdown,
     "html": render_html,

--- a/foc-review-stats/foc_review_stats/stats.py
+++ b/foc-review-stats/foc_review_stats/stats.py
@@ -33,19 +33,29 @@ class Aggregate:
 
     @property
     def logins(self) -> set[str]:
-        return set(self.authored) | set(self.reviewed)
+        authors_with_reviews = {
+            author for by_author in self.matrix.values() for author in by_author
+        }
+        return set(self.authored) | set(self.reviewed) | authors_with_reviews
 
 
 def aggregate(
     prs: Iterable[dict[str, Any]],
     ignored_lower: set[str],
     in_scope_lower: set[str] | None = None,
+    since_iso: str | None = None,
+    until_iso: str | None = None,
 ) -> Aggregate:
     """Walk a sequence of PR nodes (as returned by github.fetch_repo_prs).
 
     Skips PRs by bot or ignored authors entirely. Each reviewer is counted once
-    per PR regardless of how many review events they submitted. Self-reviews are
-    ignored.
+    per PR regardless of how many in-window review events they submitted.
+    Self-reviews are ignored.
+
+    When since_iso/until_iso are provided, PR authorship is counted only when
+    the PR creation timestamp is inside the half-open window
+    [since_iso, until_iso), and reviews are counted only when the review
+    timestamp is inside that same window.
 
     `in_scope_lower` controls team filtering:
       - `None`: no team filter, every non-bot, non-ignored login is counted.
@@ -57,6 +67,17 @@ def aggregate(
     def in_scope(login: str) -> bool:
         return in_scope_lower is None or login in in_scope_lower
 
+    def in_window(timestamp: str | None) -> bool:
+        if since_iso is None and until_iso is None:
+            return True
+        if not timestamp:
+            return False
+        if since_iso is not None and timestamp < since_iso:
+            return False
+        if until_iso is not None and timestamp >= until_iso:
+            return False
+        return True
+
     for pr in prs:
         author = pr.get("author")
         if is_bot(author, ignored_lower):
@@ -64,11 +85,14 @@ def aggregate(
         a_key = (author.get("login") or "").lower()
         if not a_key or not in_scope(a_key):
             continue
-        agg.authored[a_key] += 1
+        if in_window(pr.get("createdAt")):
+            agg.authored[a_key] += 1
 
         distinct_reviewers: set[str] = set()
         reviews = (pr.get("reviews") or {}).get("nodes") or []
         for review in reviews:
+            if not in_window(review.get("createdAt")):
+                continue
             ra = review.get("author")
             if is_bot(ra, ignored_lower):
                 continue

--- a/foc-review-stats/foc_review_stats/stats.py
+++ b/foc-review-stats/foc_review_stats/stats.py
@@ -46,7 +46,7 @@ def aggregate(
     since_iso: str | None = None,
     until_iso: str | None = None,
 ) -> Aggregate:
-    """Walk a sequence of PR nodes (as returned by github.fetch_repo_prs).
+    """Walk a sequence of PR nodes returned by the GitHub fetch helpers.
 
     Skips PRs by bot or ignored authors entirely. Each reviewer is counted once
     per PR regardless of how many in-window review events they submitted.

--- a/foc-review-stats/tests/test_stats.py
+++ b/foc-review-stats/tests/test_stats.py
@@ -1,10 +1,24 @@
 """Unit tests for aggregation logic."""
 
-from foc_review_stats.stats import aggregate, is_bot, top_given, top_received
+from foc_review_stats.render import render_markdown
+from foc_review_stats.stats import Aggregate, aggregate, is_bot, top_given, top_received
 
 
-def _pr(author_login, reviewer_logins=(), bot_author=False, bot_reviewers=()):
+def _pr(
+    author_login,
+    reviewer_logins=(),
+    bot_author=False,
+    bot_reviewers=(),
+    created_at="2026-03-10T12:00:00Z",
+    review_created_at="2026-03-10T12:00:00Z",
+):
+    review_times = (
+        review_created_at
+        if isinstance(review_created_at, list)
+        else [review_created_at] * len(reviewer_logins)
+    )
     return {
+        "createdAt": created_at,
         "author": {
             "__typename": "Bot" if bot_author else "User",
             "login": author_login,
@@ -12,13 +26,14 @@ def _pr(author_login, reviewer_logins=(), bot_author=False, bot_reviewers=()):
         "reviews": {
             "nodes": [
                 {
+                    "createdAt": review_times[i],
                     "author": {
                         "__typename": "Bot" if login in bot_reviewers else "User",
                         "login": login,
                     },
                     "state": "APPROVED",
                 }
-                for login in reviewer_logins
+                for i, login in enumerate(reviewer_logins)
             ]
         },
     }
@@ -116,6 +131,73 @@ def test_aggregate_empty_in_scope_filters_out_everyone():
     assert agg.reviewed == {}
 
 
+def test_aggregate_window_counts_reviews_on_prs_created_before_window():
+    prs = [
+        _pr(
+            "rvagg",
+            reviewer_logins=["hugomrdias"],
+            created_at="2026-02-20T12:00:00Z",
+            review_created_at="2026-03-05T12:00:00Z",
+        )
+    ]
+
+    agg = aggregate(
+        prs,
+        ignored_lower=set(),
+        since_iso="2026-03-01T00:00:00Z",
+        until_iso="2026-04-01T00:00:00Z",
+    )
+
+    assert agg.authored.get("rvagg", 0) == 0
+    assert agg.reviewed["hugomrdias"] == 1
+    assert agg.matrix["hugomrdias"]["rvagg"] == 1
+    assert "rvagg" in agg.logins
+
+
+def test_aggregate_window_filters_reviews_after_until():
+    prs = [
+        _pr(
+            "rvagg",
+            reviewer_logins=["hugomrdias"],
+            created_at="2026-03-10T12:00:00Z",
+            review_created_at="2026-04-01T00:00:00Z",
+        )
+    ]
+
+    agg = aggregate(
+        prs,
+        ignored_lower=set(),
+        since_iso="2026-03-01T00:00:00Z",
+        until_iso="2026-04-01T00:00:00Z",
+    )
+
+    assert agg.authored["rvagg"] == 1
+    assert agg.reviewed.get("hugomrdias", 0) == 0
+
+
+def test_aggregate_window_dedupes_reviewer_with_in_window_review():
+    prs = [
+        _pr(
+            "rvagg",
+            reviewer_logins=["hugomrdias", "hugomrdias", "hugomrdias"],
+            review_created_at=[
+                "2026-02-28T12:00:00Z",
+                "2026-03-05T12:00:00Z",
+                "2026-03-06T12:00:00Z",
+            ],
+        )
+    ]
+
+    agg = aggregate(
+        prs,
+        ignored_lower=set(),
+        since_iso="2026-03-01T00:00:00Z",
+        until_iso="2026-04-01T00:00:00Z",
+    )
+
+    assert agg.reviewed["hugomrdias"] == 1
+
+
 def test_top_received_and_given_are_sorted_descending():
     prs = [
         _pr("rvagg", reviewer_logins=["hugomrdias"]),
@@ -130,3 +212,10 @@ def test_top_received_and_given_are_sorted_descending():
     ]
     given = top_given("hugomrdias", agg.matrix, n=3)
     assert given == [("rvagg", 2)]
+
+
+def test_markdown_heading_describes_bounded_activity_window():
+    out = render_markdown(Aggregate(), {}, "2026-03-01", 3, until="2026-03-31")
+    assert out.splitlines()[0] == (
+        "FOC review stats (activity from 2026-03-01 through 2026-03-31)"
+    )


### PR DESCRIPTION
## Summary
- Add `--until YYYY-MM-DD` for inclusive historical report windows.
- For bounded windows, count PRs by PR creation timestamp and reviews by review submission timestamp.
- Fetch PRs updated since the window start so reviews on older PRs can be included.
- Document the new historical-window usage and add tests for event timestamp filtering.

## Why
Closes #47.

The tool previously only supported `--since`, so every report ran from the start date to today. That made it impossible to inspect a specific past month or quarter. A creation-date-only cutoff also misses reviews submitted during the period on PRs that were opened earlier.

## Behavior
- Existing behavior is unchanged when `--until` is omitted.
- With `--until`, the date range is inclusive for user input and implemented internally as a half-open timestamp window.
- A PR created before the window can still contribute review counts when a review was submitted inside the window.
- A PR created inside the window counts as authored even if it was merged or updated later.

## Validation
- `uv run pytest` -> 17 passed
- `GITHUB_TOKEN="$(gh auth token)" uv run foc-review-stats --since 2026-06-01 --until 2026-06-07 --format md -q` verified the live bounded-window query path
