### PR TITLE
feat: make endorsed-to-approved cascade explicit in SP approval template

### DIFF
--- a/.github/ISSUE_TEMPLATE/sp-approval-review.md
+++ b/.github/ISSUE_TEMPLATE/sp-approval-review.md
@@ -13,6 +13,7 @@ assignees: []
 - [ ] **New approval** — SP is being approved for the first time
 - [ ] **Breach review** — approved SP has breached SLA thresholds
 - [ ] **Periodic check** — routine re-verification of an approved SP
+- [ ] **Endorsement removal** — SP has been removed from the endorsed list, which requires removal from the approved list (see Outcome)
 
 > Some sections below are only required for breach reviews. These are marked _(breach review only)_.
 
@@ -21,6 +22,7 @@ assignees: []
 ### SP Details
 - **SP ID:**  
 - **SP Name (optional):**
+- **Endorsed SP?** Yes / No
 
 ---
 
@@ -89,7 +91,9 @@ assignees: []
 - [ ] **Approved** — SP added to approved list _(new approval / periodic check)_
 - [ ] **Not approved** — SP did not meet requirements _(new approval)_
 - [ ] **Recovered** within investigation window _(breach review)_
-- [ ] **Unapproved** _(breach review)_
+- [ ] **Unapproved** _(breach review / endorsement removal)_
+
+> **Endorsed/approved cascade:** Endorsed is a strict subset of approved. An SP cannot be endorsed without being approved, so removal from the endorsed list also requires removal from the approved list in the same action. If this SP is endorsed and the outcome is unapproval, remove it from both lists.
 
 - **Decision time (UTC):**
 - **Decision owner:**  


### PR DESCRIPTION
Closes the open question on #19 about how endorsed SPs are handled.

The endorsed list and the approved list are not independent: endorsed is a strict subset of approved, so removal from the endorsed list also requires removal from the approved list. This makes the off-endorsed-but-still-approved state (e.g. Mongo2Stor) incorrect rather than an acceptable in-between.

Three changes to the SP approval template:

- **Review Type** — adds an `Endorsement removal` trigger, so dropping an SP from the endorsed list opens a review whose outcome is removal from approved.
- **SP Details** — adds an `Endorsed SP? Yes / No` field so the reviewer always records endorsed status.
- **Outcome** — tags the `Unapproved` option with `endorsement removal` and adds a cascade note stating that an endorsed SP being unapproved must be removed from both lists.

This closes the ambiguity @beck-8 raised on #28 / #19.