### PR TITLE
ci: stabilize Ruff checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
         uses: astral-sh/setup-uv@v4
 
       - name: Ruff lint
-        run: uvx ruff check .
+        run: uvx --from ruff==0.16.1 ruff check .
 
       - name: Ruff format check
-        run: uvx ruff format --check .
+        run: uvx --from ruff==0.16.1 ruff format --check .
 
   test:
     runs-on: ubuntu-latest

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,6 @@
+target-version = "py313"
+include = ["*.py", "*.pyi", "*.ipynb"]
+
+[lint]
+# Keep the lint baseline explicit so Ruff default changes do not break CI.
+select = ["E4", "E7", "E9", "F"]


### PR DESCRIPTION
## Summary

- pin Ruff 0.16.1 in both CI lint commands
- add a repository-level Ruff configuration targeting Python 3.13
- explicitly select the traditional `E4`, `E7`, `E9`, and `F` lint baseline
- restrict Ruff discovery to Python, stub, and notebook files

## Root cause

CI used `uvx ruff`, which always downloaded the latest Ruff release. Ruff 0.16.1 expanded its default rules and file inclusion, so the existing repository suddenly produced 399 lint errors and Ruff also attempted to format Python snippets in Markdown. The failures were unrelated to PR #52.